### PR TITLE
Add RemoveCommand class to remove user keys

### DIFF
--- a/src/AddCommand.php
+++ b/src/AddCommand.php
@@ -21,7 +21,7 @@ class AddCommand extends Command {
     $response = (new Client)->get(self::DEFAULT_HOSTNAME.'/users/'.$input->getArgument('user').'/keys');
 
     $this->write_to_file(json_decode($response->getBody()), self::getKeysFile(), $input->getArgument('user'));
-    $output->writeln("<info>Successfully added ".$input->getArgument('user')." to authorized keys</info>");
+    $output->writeln("<info>Successfully added ".$input->getArgument('user')." to your authorized keys file</info>");
   }
 
   private function write_to_file($keys, $file, $user)
@@ -31,10 +31,11 @@ class AddCommand extends Command {
     }
     $fh = fopen($file, 'a');
     foreach($keys as $key) {
-      $gh = $key->key . " " . $user;
+      $gh = $key->key . " " . $user . "\n";
       if(!fwrite($fh, $gh)) {
         throw new RuntimeException("Not able to write to the file.");
       }
     }
+    fclose($fh);
   }
 }

--- a/src/Command.php
+++ b/src/Command.php
@@ -9,31 +9,22 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Command extends SymfonyCommand {
 
-  protected $default_path;
-  protected $gh_url;
+  const DEFAULT_PATH = "/.ssh/authorized_keys";
+  const DEFAULT_HOSTNAME = "https://api.github.com";
 
   public function __construct()
   {
-    $this->defualt_path = "/.ssh/authorized_keys";
-    $this->gh_url = "https://api.github.com";
-
     parent::__construct();
   }
 
   public static function getKeysFile()
   {
-    return getenv('HOME'). $this->default_path;
+    return getenv('HOME').self::DEFAULT_PATH;
   }
 
   protected function getKeysCount()
   {
-    $count = 0;
-    $fh = fopen(self::getKeysFile(), 'r');
-    if($fh) {
-      while(($buffer = fgets($fh, 2)) !== false){
-        $count++;
-      }
-    }
-    return $count;
+    $count = file(self::getKeysFile());
+    return count($count);
   }
 }

--- a/src/RemoveCommand.php
+++ b/src/RemoveCommand.php
@@ -16,6 +16,26 @@ class RemoveCommand extends Command {
 
   public function execute(InputInterface $input, OutputInterface $output)
   {
+    $user = $input->getArgument('user');
+  }
 
+  private function remove_from_file($user, $file)
+  {
+    $allUsers = file($file, FILE_IGNORE_NEW_LINES);
+
+  }
+
+  private function write_to_file($keys, $file, $user)
+  {
+    if (!file_exists($file)) {
+      touch($file);
+    }
+    $fh = fopen($file, 'a');
+    foreach($keys as $key) {
+      $gh = $key->key . " " . $user;
+      if(!fwrite($fh, $gh)) {
+        throw new RuntimeException("Not able to write to the file.");
+      }
+    }
   }
 }

--- a/src/RemoveCommand.php
+++ b/src/RemoveCommand.php
@@ -7,6 +7,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RemoveCommand extends Command {
 
+  private $removed;
+
+  public function __construct()
+  {
+    $this->removed = 0;
+    parent::__construct();
+  }
+
   public function configure()
   {
     $this->setName('remove')
@@ -17,25 +25,37 @@ class RemoveCommand extends Command {
   public function execute(InputInterface $input, OutputInterface $output)
   {
     $user = $input->getArgument('user');
+    if ($this->remove_from_file($user, self::getKeysFile())){
+      $output->writeln("<info>Removed ".$this->removed." keys from your authorized_keys file</info>");
+    } else {
+      $output->writeln("<error>ERROR!?!? Removing keys was unsucessful</error>");
+    }
   }
 
   private function remove_from_file($user, $file)
   {
     $allUsers = file($file, FILE_IGNORE_NEW_LINES);
-
+    $matches = preg_grep('/'.$user.'/', $allUsers);
+    $this->removed = count($matches);
+    $arrLeft = array_diff($allUsers, $matches);
+    return $this->write_to_file($arrLeft, $file);
   }
 
-  private function write_to_file($keys, $file, $user)
+  private function write_to_file($keys, $file)
   {
-    if (!file_exists($file)) {
-      touch($file);
-    }
-    $fh = fopen($file, 'a');
-    foreach($keys as $key) {
-      $gh = $key->key . " " . $user;
-      if(!fwrite($fh, $gh)) {
-        throw new RuntimeException("Not able to write to the file.");
+    if(count($keys) > 0){
+      $fh = fopen($file, 'w');
+      foreach($keys as $key) {
+        if($key != ""){
+          if(!fwrite($fh, $key."\n")) {
+            throw new RuntimeException("Not able to write to the file.");
+          }
+        }
       }
+      return fclose($fh);
+    } else {
+      unlink($file);
+      return true;
     }
   }
 }


### PR DESCRIPTION
This commit adds all the functions needed to remove a users key from the
`~/.ssh/authorized_keys` file.  This commit also puts the constants back
into `Command` class.

[145204689258668](https://app.asana.com/0/145204689258668/145204689258668)
